### PR TITLE
fix: use correct context value ref

### DIFF
--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -10,7 +10,6 @@ import (
 )
 
 type key int
-
 const userKey key = iota
 
 func MockUser(next http.HandlerFunc, user string) http.HandlerFunc {
@@ -30,7 +29,7 @@ func RequireToken(next http.HandlerFunc) http.HandlerFunc {
 				log.Println("Error: ", err)
 				ReturnUnauthorized(w)
 			} else {
-				next(w, r.WithContext(context.WithValue(r.Context(), userKey, parsedToken.Claims["email"].(string))))
+				next(w, r.WithContext(context.WithValue(r.Context(), userKey, parsedToken.Claims["email"])))
 			}
 		} else {
 			ReturnUnauthorized(w)

--- a/internal/handlers/index.go
+++ b/internal/handlers/index.go
@@ -9,7 +9,7 @@ import (
 )
 
 func IndexPage(w http.ResponseWriter, r *http.Request) {
-	user := r.Context().Value("user-email").(string)
+	user := r.Context().Value(userKey).(string)
 	data := struct {
 		Name     string
 		Policies []policy.Policy


### PR DESCRIPTION
Forgot to change the context value reference (from a string type to the userKey type). This PR fixes it